### PR TITLE
Refactor blur score helpers for readability

### DIFF
--- a/util/blur_score.py
+++ b/util/blur_score.py
@@ -15,6 +15,7 @@ import os
 import subprocess
 import tempfile
 import warnings
+
 import numpy as np
 
 DEFAULT_TARGET_FWHM = 3.0
@@ -131,10 +132,18 @@ def compute_blur_score(image, target_fwhm=DEFAULT_TARGET_FWHM, **kwargs):
     return score_from_psf(*measure_psf(image, **kwargs), target_fwhm=target_fwhm)
 
 
+def _clip01(value):
+    return float(np.clip(value, 0.0, 1.0))
+
+
 def score_from_psf(fwhm, ecc, n_bright, target_fwhm):
-    fwhm_score = min(1.0, target_fwhm / fwhm) if fwhm > 0 else 0.0
-    shape_weight = max(0.0, 1.0 - ecc)
-    count_weight = min(1.0, n_bright / COUNT_SATURATION)
+    """Compute final score from PSF summary statistics.
+
+    Uses robust medians from ``measure_psf`` and clips each component to [0, 1].
+    """
+    fwhm_score = _clip01(target_fwhm / fwhm) if fwhm > 0 else 0.0
+    shape_weight = _clip01(1.0 - ecc)
+    count_weight = _clip01(n_bright / COUNT_SATURATION)
     return float(fwhm_score * shape_weight * count_weight)
 
 

--- a/util/blur_score_benchmark.py
+++ b/util/blur_score_benchmark.py
@@ -24,13 +24,12 @@ IMG_EXTS = (".fits", ".fit", ".fts", ".png", ".jpg", ".jpeg", ".tif", ".tiff")
 
 
 def _walk_images(root):
-    out = []
-    for dirpath, _, files in os.walk(root):
-        for fn in files:
-            if fn.lower().endswith(IMG_EXTS):
-                out.append(os.path.join(dirpath, fn))
-    out.sort()
-    return out
+    return sorted(
+        os.path.join(dirpath, fn)
+        for dirpath, _, files in os.walk(root)
+        for fn in files
+        if fn.lower().endswith(IMG_EXTS)
+    )
 
 
 def main(argv=None):


### PR DESCRIPTION
### Motivation
- Simplify and clarify the blur scoring code-path to make the composition of score factors explicit and make image discovery in the benchmark script more concise.

### Description
- Introduced a small `_clip01()` helper and replaced inlined clipping logic in `score_from_psf()` while adding a short docstring, and simplified `_walk_images()` in `util/blur_score_benchmark.py` to use a sorted generator expression instead of manual list-building.

### Testing
- Ran `python -m unittest util.test_blur_score`, which could not execute in this environment due to missing dependency (`ModuleNotFoundError: No module named 'numpy'`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a1201b7a08325a5843738c5d02793)