### PR TITLE
Rewrite C file handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,16 @@ util/wcs-match
 util/wcs-pv2sip
 report.txt
 .DS_Store
+.idea/
+.idea/
+
+# Generated solve-field/evaluation artifacts. Keep result summaries and code
+# such as .csv, .md, and .py files visible to Git.
+*.axy
+*.corr
+*.match
+*.new
+*.rdls
+*.solved
+*.wcs
+*.xyls

--- a/include/astrometry/augment-xylist.h
+++ b/include/astrometry/augment-xylist.h
@@ -82,6 +82,7 @@ struct augment_xylist_s {
     anbool force_ppm;
 
     anbool use_source_extractor;
+    anbool use_sep;
     char* source_extractor_path;
     char* source_extractor_config;
 
@@ -172,5 +173,4 @@ void augment_xylist_print_special_opts(an_option_t* opt, bl* opts,
                                        FILE* fid, void* extra);
 
 #endif
-
 

--- a/include/astrometry/image2xy-files.h
+++ b/include/astrometry/image2xy-files.h
@@ -27,4 +27,13 @@ int image2xy_files(const char* infn, const char* outfn,
                    int extension, int plane,
                    simplexy_t* params);
 
+/**
+ Optional SEP-backed source extraction.  This function is always available
+ as a symbol, but returns an error unless the binary was built with HAVE_SEP.
+ */
+int image2xy_files_sep(const char* infn, const char* outfn,
+                       int downsample, int downsample_as_required,
+                       int extension, int plane,
+                       simplexy_t* params);
+
 #endif

--- a/include/astrometry/simplexy.h
+++ b/include/astrometry/simplexy.h
@@ -64,6 +64,9 @@ struct simplexy_t {
     float *y;
     float *flux;
     float *background;
+    // Moment-based source shape estimates, one per detected peak.
+    float *fwhm;
+    float *ellipticity;
     int npeaks;
 
     // Lanczos-interpolated flux and backgrounds;

--- a/solver/Makefile
+++ b/solver/Makefile
@@ -21,6 +21,7 @@ export SYSTEM_GSL
 include $(COMMON)/makefile.common
 include $(COMMON)/makefile.anfiles
 include $(COMMON)/makefile.cfitsio
+include $(COMMON)/makefile.sep
 # only for tweak-main.c
 include $(COMMON)/makefile.png
 include $(COMMON)/makefile.cairo
@@ -44,6 +45,7 @@ LDFLAGS := $(LDFLAGS_DEF)
 
 LDLIBS := $(LDLIBS_DEF)
 LDLIBS += $(ANFILES_LIB)
+LDLIBS += $(SEP_LIB)
 
 SLIB := $(ENGINE_LIB)
 SLIB += $(CATS_SLIB)
@@ -53,6 +55,8 @@ CFLAGS += $(CFLAGS_DEF)
 CFLAGS += $(CATS_INC)
 CFLAGS += $(ANFILES_CFLAGS)
 CFLAGS += $(ANFILES_INC)
+CFLAGS += $(SEP_CFLAGS)
+CFLAGS += $(SEP_INC)
 # boilerplate.h
 CFLAGS += -I$(ANUTILS_DIR)
 # wcs-resample.h

--- a/solver/augment-xylist.c
+++ b/solver/augment-xylist.c
@@ -141,6 +141,12 @@ static an_option_t options[] = {
      "odds ratio at which to stop adding stars when evaluating a hypothesis (default: LARGE_VAL)"},
     {'^', "use-source-extractor", no_argument, NULL,
      "use SourceExtractor rather than built-in image2xy to find sources"},
+    {'\x95', "use-sep", no_argument, NULL,
+     "use the SEP library rather than built-in image2xy to find sources.  "
+     "Requires building with HAVE_SEP=yes."},
+    {'\x96', "source-backend", required_argument, "simplexy|sep|source-extractor",
+     "source extraction backend.  Default: simplexy.  This is the preferred "
+     "form of --use-sep and --use-source-extractor."},
     {'&', "source-extractor-config", required_argument, "filename",
      "use the given SourceExtractor config file.  "
      "Note that CATALOG_NAME and CATALOG_TYPE values will be over-ridden by command-line values.  "
@@ -327,6 +333,24 @@ int augment_xylist_parse_option(char argchar, char* optarg,
         break;
     case '^':
         axy->use_source_extractor = TRUE;
+        break;
+    case '\x95':
+        axy->use_sep = TRUE;
+        break;
+    case '\x96':
+        if (streq(optarg, "simplexy")) {
+            axy->use_sep = FALSE;
+            axy->use_source_extractor = FALSE;
+        } else if (streq(optarg, "sep")) {
+            axy->use_sep = TRUE;
+            axy->use_source_extractor = FALSE;
+        } else if (streq(optarg, "source-extractor")) {
+            axy->use_sep = FALSE;
+            axy->use_source_extractor = TRUE;
+        } else {
+            ERROR("Unknown source backend \"%s\".  Choices are: simplexy, sep, source-extractor", optarg);
+            return -1;
+        }
         break;
     case '&':
         axy->source_extractor_config = optarg;
@@ -682,6 +706,11 @@ int augment_xylist(augment_xylist_t* axy,
     tempfiles = sl_new(4);
     scales = dl_new(4);
 
+    if (axy->use_sep && axy->use_source_extractor) {
+        ERROR("Choose only one source extraction backend: --use-sep or --use-source-extractor");
+        return -1;
+    }
+
     if (axy->imagefn) {
         // if --image is given:
         //       -run image2pnm
@@ -865,7 +894,31 @@ int augment_xylist(augment_xylist_t* axy,
         xylsfn = create_temp_file("xyls", axy->tempdir);
         sl_append_nocopy(tempfiles, xylsfn);
 
-        if (axy->use_source_extractor) {
+        if (axy->use_sep) {
+            simplexy_t sxyparams;
+            logverb("Running SEP image2xy: input=%s, output=%s, ext=%i\n",
+                    fitsimgfn, xylsfn, axy->fitsimgext);
+
+            // we have to delete the temp file because otherwise image2xy is too timid to overwrite it.
+            if (unlink(xylsfn)) {
+                SYSERROR("Failed to delete temp file %s", xylsfn);
+                exit(-1);
+            }
+
+            memset(&sxyparams, 0, sizeof(simplexy_t));
+            sxyparams.nobgsub = axy->no_bg_subtraction;
+            sxyparams.sigma = axy->image_sigma;
+            sxyparams.invert = axy->invert_image;
+            sxyparams.plim = axy->image_nsigma;
+
+            // MAGIC 3: downsample by a factor of 2, up to 3 times.
+            if (image2xy_files_sep(fitsimgfn, xylsfn, axy->downsample, 3,
+                                   axy->fitsimgext, 0, &sxyparams)) {
+                ERROR("SEP source extraction failed");
+                exit(-1);
+            }
+
+        } else if (axy->use_source_extractor) {
             if (axy->source_extractor_path)
                 sl_append(cmd, axy->source_extractor_path);
             else
@@ -881,7 +934,7 @@ int augment_xylist(augment_xylist_t* axy,
 
                 paramfn = create_temp_file("param", axy->tempdir);
                 sl_append_nocopy(tempfiles, paramfn);
-                paramstr = "X_IMAGE\nY_IMAGE\nMAG_AUTO\nFLUX_AUTO";
+                paramstr = "X_IMAGE\nY_IMAGE\nMAG_AUTO\nFLUX_AUTO\nFWHM_IMAGE\nELLIPTICITY";
                 if (write_file(paramfn, paramstr, strlen(paramstr))) {
                     ERROR("Failed to write Source Extractor parameters to temp file \"%s\"", paramfn);
                     exit(-1);
@@ -1602,4 +1655,3 @@ static int parse_fields_string(il* fields, const char* str) {
     }
     return 0;
 }
-

--- a/solver/image2xy-files.c
+++ b/solver/image2xy-files.c
@@ -20,6 +20,137 @@
 #include "errors.h"
 #include "log.h"
 #include "cfitsutils.h"
+#include "dimage.h"
+#include "mathutil.h"
+
+#ifdef HAVE_SEP
+#include <sep.h>
+#endif
+
+static int source_table_check_status(int status, const char* msg) {
+    if (status) {
+        cfitserr(status);
+        ERROR("%s", msg);
+        return -1;
+    }
+    return 0;
+}
+
+#define SOURCE_TABLE_CHECK(msg)                         \
+do {                                                    \
+    if (source_table_check_status(*status, msg))        \
+        return -1;                                      \
+} while (0)
+
+static int write_source_table(fitsfile* ofptr, const simplexy_t* params,
+                              int src_ext, int imagew, int imageh,
+                              const char* backend, int* status) {
+    char* ttype[] = {"X", "Y", "FLUX", "BACKGROUND",
+                     "FWHM_IMAGE", "ELLIPTICITY", "LFLUX", "LBG"};
+    char* tform[] = {"E", "E", "E", "E", "E", "E", "E", "E"};
+    char* tunit[] = {"pix", "pix", "unknown", "unknown",
+                     "pix", "", "unknown", "unknown"};
+    int ncols = params->Lorder ? 8 : 6;
+    int npeaks = params->npeaks;
+    float sigma = params->sigma;
+    float dpsf = params->dpsf;
+    float plim = params->plim;
+    float dlim = params->dlim;
+    float saddle = params->saddle;
+    int maxper = params->maxper;
+    int maxnpeaks = params->maxnpeaks;
+    int maxsize = params->maxsize;
+    int halfbox = params->halfbox;
+
+    fits_create_tbl(ofptr, BINARY_TBL, params->npeaks, ncols, ttype, tform,
+                    tunit, "SOURCES", status);
+    SOURCE_TABLE_CHECK("Failed to create output table");
+
+    if (params->npeaks) {
+        fits_write_col(ofptr, TFLOAT, 1, 1, 1, params->npeaks, params->x, status);
+        SOURCE_TABLE_CHECK("Failed to write X column");
+
+        fits_write_col(ofptr, TFLOAT, 2, 1, 1, params->npeaks, params->y, status);
+        SOURCE_TABLE_CHECK("Failed to write Y column");
+
+        fits_write_col(ofptr, TFLOAT, 3, 1, 1, params->npeaks, params->flux, status);
+        SOURCE_TABLE_CHECK("Failed to write FLUX column");
+
+        fits_write_col(ofptr, TFLOAT, 4, 1, 1, params->npeaks, params->background, status);
+        SOURCE_TABLE_CHECK("Failed to write BACKGROUND column");
+
+        fits_write_col(ofptr, TFLOAT, 5, 1, 1, params->npeaks, params->fwhm, status);
+        SOURCE_TABLE_CHECK("Failed to write FWHM_IMAGE column");
+
+        fits_write_col(ofptr, TFLOAT, 6, 1, 1, params->npeaks, params->ellipticity, status);
+        SOURCE_TABLE_CHECK("Failed to write ELLIPTICITY column");
+
+        if (params->Lorder) {
+            fits_write_col(ofptr, TFLOAT, 7, 1, 1, params->npeaks, params->fluxL, status);
+            SOURCE_TABLE_CHECK("Failed to write LFLUX column");
+
+            fits_write_col(ofptr, TFLOAT, 8, 1, 1, params->npeaks, params->backgroundL, status);
+            SOURCE_TABLE_CHECK("Failed to write LBG column");
+        }
+    }
+
+    fits_modify_comment(ofptr, "TTYPE1", "X coordinate", status);
+    SOURCE_TABLE_CHECK("Failed to set X TTYPE");
+
+    fits_modify_comment(ofptr, "TTYPE2", "Y coordinate", status);
+    SOURCE_TABLE_CHECK("Failed to set Y TTYPE");
+
+    fits_modify_comment(ofptr, "TTYPE3", "Flux of source", status);
+    SOURCE_TABLE_CHECK("Failed to set FLUX TTYPE");
+
+    fits_modify_comment(ofptr, "TTYPE4", "Sky background of source", status);
+    SOURCE_TABLE_CHECK("Failed to set BACKGROUND TTYPE");
+
+    fits_modify_comment(ofptr, "TTYPE5", "Moment-based source FWHM estimate", status);
+    SOURCE_TABLE_CHECK("Failed to set FWHM_IMAGE TTYPE");
+
+    fits_modify_comment(ofptr, "TTYPE6", "Moment-based source ellipticity estimate", status);
+    SOURCE_TABLE_CHECK("Failed to set ELLIPTICITY TTYPE");
+
+    fits_write_key(ofptr, TINT, "SRCEXT", &src_ext,
+                   "Extension number in src image", status);
+    SOURCE_TABLE_CHECK("Failed to write SRCEXT");
+
+    fits_write_key(ofptr, TSTRING, "SRCBACK", (char*)backend,
+                   "Source extraction backend", status);
+    SOURCE_TABLE_CHECK("Failed to write SRCBACK");
+
+    fits_write_key(ofptr, TINT, "IMAGEW", &imagew, "Input image width", status);
+    SOURCE_TABLE_CHECK("Failed to write IMAGEW");
+
+    fits_write_key(ofptr, TINT, "IMAGEH", &imageh, "Input image height", status);
+    SOURCE_TABLE_CHECK("Failed to write IMAGEH");
+
+    fits_write_key(ofptr, TFLOAT, "ESTSIGMA", &sigma,
+                   "Estimated source image variance", status);
+    SOURCE_TABLE_CHECK("Failed to write ESTSIGMA");
+
+    fits_write_key(ofptr, TINT, "NPEAKS", &npeaks, "image2xy Number of peaks found", status);
+    fits_write_key(ofptr, TFLOAT, "DPSF", &dpsf, "image2xy Assumed gaussian psf width", status);
+    fits_write_key(ofptr, TFLOAT, "PLIM", &plim, "image2xy Significance to keep", status);
+    fits_write_key(ofptr, TFLOAT, "DLIM", &dlim, "image2xy Closest two peaks can be", status);
+    fits_write_key(ofptr, TFLOAT, "SADDLE", &saddle, "image2xy Saddle difference (in sig)", status);
+    fits_write_key(ofptr, TINT, "MAXPER", &maxper, "image2xy Max num of peaks per object", status);
+    fits_write_key(ofptr, TINT, "MAXPEAKS", &maxnpeaks, "image2xy Max num of peaks total", status);
+    fits_write_key(ofptr, TINT, "MAXSIZE", &maxsize, "image2xy Max size for extended objects", status);
+    fits_write_key(ofptr, TINT, "HALFBOX", &halfbox, "image2xy Half-size for sliding sky window", status);
+    SOURCE_TABLE_CHECK("Failed to write source extraction parameters");
+
+    fits_write_comment(ofptr,
+                       "The X and Y points are specified assuming 1,1 is "
+                       "the center of the leftmost bottom pixel of the "
+                       "image in accordance with the FITS standard.", status);
+    SOURCE_TABLE_CHECK("Failed to write comments");
+
+    return 0;
+}
+
+#undef SOURCE_TABLE_CHECK
 
 int image2xy_files(const char* infn, const char* outfn,
                    anbool do_u8, int downsample, int downsample_as_required,
@@ -93,14 +224,10 @@ int image2xy_files(const char* infn, const char* outfn,
 
     // Run simplexy on each HDU
     for (kk=1; kk <= nhdus; kk++) {
-        char* ttype[] = {"X","Y","FLUX","BACKGROUND", "LFLUX", "LBG"};
-        char* tform[] = {"E","E","E","E","E","E"};
-        char* tunit[] = {"pix","pix","unknown","unknown","unknown","unknown"};
         long* fpixel;
         int a;
         int w, h;
         int bitpix;
-        int ncols;
 
         if (extension && kk != extension)
             continue;
@@ -173,77 +300,10 @@ int image2xy_files(const char* infn, const char* outfn,
 
         image2xy_run(params, downsample, downsample_as_required);
 
-        if (params->Lorder)
-            ncols = 6;
-        else
-            ncols = 4;
-        fits_create_tbl(ofptr, BINARY_TBL, params->npeaks, ncols, ttype, tform,
-                        tunit, "SOURCES", &status);
-        CFITS_CHECK("Failed to create output table");
-
-        fits_write_col(ofptr, TFLOAT, 1, 1, 1, params->npeaks, params->x, &status);
-        CFITS_CHECK("Failed to write X column");
-
-        fits_write_col(ofptr, TFLOAT, 2, 1, 1, params->npeaks, params->y, &status);
-        CFITS_CHECK("Failed to write Y column");
-
-        fits_write_col(ofptr, TFLOAT, 3, 1, 1, params->npeaks, params->flux, &status);
-        CFITS_CHECK("Failed to write FLUX column");
-
-        fits_write_col(ofptr, TFLOAT, 4, 1, 1, params->npeaks, params->background, &status);
-        CFITS_CHECK("Failed to write BACKGROUND column");
-
-        if (params->Lorder) {
-            fits_write_col(ofptr, TFLOAT, 5, 1, 1, params->npeaks, params->fluxL, &status);
-            CFITS_CHECK("Failed to write LFLUX column");
-
-            fits_write_col(ofptr, TFLOAT, 6, 1, 1, params->npeaks, params->backgroundL, &status);
-            CFITS_CHECK("Failed to write LBG column");
-        }
-
-        fits_modify_comment(ofptr, "TTYPE1", "X coordinate", &status);
-        CFITS_CHECK("Failed to set X TTYPE");
-
-        fits_modify_comment(ofptr, "TTYPE2", "Y coordinate", &status);
-        CFITS_CHECK("Failed to set Y TTYPE");
-
-        fits_modify_comment(ofptr, "TTYPE3", "Flux of source", &status);
-        CFITS_CHECK("Failed to set FLUX TTYPE");
-
-        fits_modify_comment(ofptr, "TTYPE4", "Sky background of source", &status);
-        CFITS_CHECK("Failed to set BACKGROUND TTYPE");
-
-        fits_write_key(ofptr, TINT, "SRCEXT", &kk,
-                       "Extension number in src image", &status);
-        CFITS_CHECK("Failed to write SRCEXT");
-
         w = naxisn[0];
         h = naxisn[1];
-        fits_write_key(ofptr, TINT, "IMAGEW", &w, "Input image width", &status);
-        CFITS_CHECK("Failed to write IMAGEW");
-
-        fits_write_key(ofptr, TINT, "IMAGEH", &h, "Input image height", &status);
-        CFITS_CHECK("Failed to write IMAGEH");
-
-        fits_write_key(ofptr, TFLOAT, "ESTSIGMA", &(params->sigma),
-                       "Estimated source image variance", &status);
-        CFITS_CHECK("Failed to write ESTSIGMA");
-
-	fits_write_key(ofptr, TINT, "NPEAKS", &(params->npeaks), "image2xy Number of peaks found", &status);
-        fits_write_key(ofptr, TFLOAT, "DPSF", &(params->dpsf), "image2xy Assumed gaussian psf width", &status);
-        fits_write_key(ofptr, TFLOAT, "PLIM", &(params->plim), "image2xy Significance to keep", &status);
-        fits_write_key(ofptr, TFLOAT, "DLIM", &(params->dlim), "image2xy Closest two peaks can be", &status);
-        fits_write_key(ofptr, TFLOAT, "SADDLE", &(params->saddle), "image2xy Saddle difference (in sig)", &status);
-        fits_write_key(ofptr, TINT, "MAXPER", &(params->maxper), "image2xy Max num of peaks per object", &status);
-        fits_write_key(ofptr, TINT, "MAXPEAKS", &(params->maxnpeaks), "image2xy Max num of peaks total", &status);
-        fits_write_key(ofptr, TINT, "MAXSIZE", &(params->maxsize), "image2xy Max size for extended objects", &status);
-        fits_write_key(ofptr, TINT, "HALFBOX", &(params->halfbox), "image2xy Half-size for sliding sky window", &status);
-
-        fits_write_comment(ofptr,
-                           "The X and Y points are specified assuming 1,1 is "
-                           "the center of the leftmost bottom pixel of the "
-                           "image in accordance with the FITS standard.", &status);
-        CFITS_CHECK("Failed to write comments");
+        if (write_source_table(ofptr, params, kk, w, h, "simplexy", &status))
+            goto bailout;
 
         simplexy_free_contents(params);
     }
@@ -275,3 +335,397 @@ int image2xy_files(const char* infn, const char* outfn,
         fits_close_file(ofptr, &status);
     return -1;
 }
+
+#ifdef HAVE_SEP
+
+static int sep_check_status(int status, const char* msg) {
+    char errtext[128];
+    char detail[512];
+
+    if (!status)
+        return 0;
+
+    errtext[0] = '\0';
+    detail[0] = '\0';
+    sep_get_errmsg(status, errtext);
+    sep_get_errdetail(detail);
+    if (detail[0])
+        ERROR("%s: %s (%s)", msg, errtext, detail);
+    else
+        ERROR("%s: %s", msg, errtext);
+    return -1;
+}
+
+static void sep_make_filter(float* conv) {
+    static const float raw[] = {
+        0.006319f, 0.040599f, 0.075183f, 0.040599f, 0.006319f,
+        0.040599f, 0.260856f, 0.483068f, 0.260856f, 0.040599f,
+        0.075183f, 0.483068f, 0.894573f, 0.483068f, 0.075183f,
+        0.040599f, 0.260856f, 0.483068f, 0.260856f, 0.040599f,
+        0.006319f, 0.040599f, 0.075183f, 0.040599f, 0.006319f
+    };
+    double sum = 0.0;
+    int i;
+
+    for (i=0; i<25; i++)
+        sum += raw[i];
+    for (i=0; i<25; i++)
+        conv[i] = raw[i] / sum;
+}
+
+static int sep_downsample_image(float** image, int* W, int* H, int S) {
+    int newW, newH;
+
+    if (S <= 1)
+        return 0;
+
+    get_output_image_size(*W, *H, S, EDGE_AVERAGE, &newW, &newH);
+    dsmooth2(*image, *W, *H, (float)S, *image);
+    if (!average_image_f(*image, *W, *H, S, EDGE_AVERAGE, &newW, &newH, *image)) {
+        ERROR("Averaging the image for SEP downsampling failed.");
+        return -1;
+    }
+
+    *W = newW;
+    *H = newH;
+    return 0;
+}
+
+static int sep_fill_output(simplexy_t* params, sep_catalog* catalog,
+                           const sep_bkg* bkg, int scale) {
+    const double fwhm_factor = 2.3548200450309493;
+    int i;
+    int n;
+
+    n = catalog->nobj;
+    if (params->maxnpeaks && n > params->maxnpeaks)
+        n = params->maxnpeaks;
+
+    params->npeaks = n;
+    if (!n)
+        return 0;
+
+    params->x = calloc(n, sizeof(float));
+    params->y = calloc(n, sizeof(float));
+    params->flux = calloc(n, sizeof(float));
+    params->background = calloc(n, sizeof(float));
+    params->fwhm = calloc(n, sizeof(float));
+    params->ellipticity = calloc(n, sizeof(float));
+    if (!params->x || !params->y || !params->flux || !params->background ||
+        !params->fwhm || !params->ellipticity) {
+        SYSERROR("Failed to allocate SEP source output arrays");
+        return -1;
+    }
+
+    for (i=0; i<n; i++) {
+        double a = catalog->a[i];
+        double b = catalog->b[i];
+        int64_t bx = catalog->xpeak[i];
+        int64_t by = catalog->ypeak[i];
+
+        params->x[i] = (float)((catalog->x[i] + 0.5) * (double)scale + 0.5);
+        params->y[i] = (float)((catalog->y[i] + 0.5) * (double)scale + 0.5);
+        params->flux[i] = catalog->flux[i];
+
+        if (bkg) {
+            bx = MAX(0, MIN((int64_t)params->nx - 1, bx));
+            by = MAX(0, MIN((int64_t)params->ny - 1, by));
+            params->background[i] = sep_bkg_pix(bkg, bx, by);
+        } else
+            params->background[i] = 0.0f;
+
+        if (a < b) {
+            double tmp = a;
+            a = b;
+            b = tmp;
+        }
+
+        params->fwhm[i] = 0.0f;
+        params->ellipticity[i] = 1.0f;
+        if (a > 0.0 && b >= 0.0) {
+            params->fwhm[i] = (float)(fwhm_factor *
+                                      sqrt((a * a + b * b) / 2.0) *
+                                      (double)scale);
+            params->ellipticity[i] = (float)(1.0 - b / a);
+        }
+    }
+
+    return 0;
+}
+
+static int sep_extract_image(simplexy_t* params, int scale) {
+    sep_image image;
+    sep_bkg* bkg = NULL;
+    sep_catalog* catalog = NULL;
+    float* work = NULL;
+    float conv[25];
+    float threshold;
+    float globalbg = 0.0f;
+    int status;
+    int i;
+    int rtn = -1;
+
+    memset(&image, 0, sizeof(sep_image));
+
+    work = malloc((size_t)params->nx * (size_t)params->ny * sizeof(float));
+    if (!work) {
+        SYSERROR("Failed to allocate SEP working image");
+        goto bailout;
+    }
+    memcpy(work, params->image, (size_t)params->nx * (size_t)params->ny * sizeof(float));
+
+    if (params->invert) {
+        for (i=0; i<(params->nx * params->ny); i++)
+            work[i] = -work[i];
+    }
+
+    image.data = work;
+    image.dtype = SEP_TFLOAT;
+    image.w = params->nx;
+    image.h = params->ny;
+    image.noise_type = SEP_NOISE_STDDEV;
+
+    status = sep_background(&image, 64, 64, 3, 3, 0.0, &bkg);
+    if (sep_check_status(status, "SEP background estimation failed"))
+        goto bailout;
+
+    globalbg = sep_bkg_global(bkg);
+    if (params->sigma == 0.0f)
+        params->sigma = sep_bkg_globalrms(bkg);
+    params->globalbg = globalbg;
+
+    if (!params->nobgsub) {
+        status = sep_bkg_subarray(bkg, work, SEP_TFLOAT);
+        if (sep_check_status(status, "SEP background subtraction failed"))
+            goto bailout;
+    }
+
+    threshold = params->plim * params->sigma;
+    if (!isfinite(threshold) || threshold <= 0.0f)
+        threshold = params->plim;
+
+    sep_make_filter(conv);
+    status = sep_extract(&image, threshold, SEP_THRESH_ABS, 5,
+                         conv, 5, 5, SEP_FILTER_CONV,
+                         32, 0.005, 1, 1.0, &catalog);
+    if (sep_check_status(status, "SEP source extraction failed"))
+        goto bailout;
+
+    if (sep_fill_output(params, catalog, bkg, scale))
+        goto bailout;
+
+    logverb("SEP: found %i sources.\n", params->npeaks);
+    rtn = 0;
+
+ bailout:
+    if (catalog)
+        sep_catalog_free(catalog);
+    if (bkg)
+        sep_bkg_free(bkg);
+    free(work);
+    return rtn;
+}
+
+int image2xy_files_sep(const char* infn, const char* outfn,
+                       int downsample, int downsample_as_required,
+                       int extension, int plane,
+                       simplexy_t* params) {
+    fitsfile *fptr = NULL;
+    fitsfile *ofptr = NULL;
+    int status = 0;
+    int naxis;
+    long naxisn[3];
+    int kk;
+    int nhdus, hdutype, nimgs;
+    char* str;
+    simplexy_t myparams;
+
+    if (params == NULL) {
+        memset(&myparams, 0, sizeof(simplexy_t));
+        params = &myparams;
+    }
+
+    // QFITS to CFITSIO extension convention switch
+    extension++;
+
+    fits_open_file(&fptr, infn, READONLY, &status);
+    CFITS_CHECK("Failed to open FITS input file %s", infn);
+
+    fits_get_num_hdus(fptr, &nhdus, &status);
+    CFITS_CHECK("Failed to read number of HDUs for input file %s", infn);
+    logverb("nhdus=%d\n", nhdus);
+
+    if (extension > nhdus) {
+        logerr("Requested extension %i is greater than number of extensions (%i) in file %s\n",
+               extension, nhdus, infn);
+        goto bailout;
+    }
+
+    fits_create_file(&ofptr, outfn, &status);
+    CFITS_CHECK("Failed to open FITS output file %s", outfn);
+
+    fits_create_img(ofptr, 8, 0, NULL, &status);
+    CFITS_CHECK("Failed to create output image");
+
+    fits_write_key(ofptr, TSTRING, "SRCFN", (char*)infn, "Source image", &status);
+    if (extension)
+        fits_write_key(ofptr, TINT, "SRCEXT", &extension, "Source image extension (1=primary)", &status);
+
+    fits_write_comment(ofptr, "Parameters used for SEP source extraction", &status);
+
+    fits_write_history(ofptr, "Created by Astrometry.net's image2xy program.", &status);
+    CFITS_CHECK("Failed to write HISTORY headers");
+
+    asprintf_safe(&str, "GIT URL: %s", AN_GIT_URL);
+    fits_write_history(ofptr, str, &status);
+    CFITS_CHECK("Failed to write GIT HISTORY headers");
+    free(str);
+    asprintf_safe(&str, "GIT Rev: %s", AN_GIT_REVISION);
+    fits_write_history(ofptr, str, &status);
+    CFITS_CHECK("Failed to write GIT HISTORY headers");
+    free(str);
+    asprintf_safe(&str, "GIT Date: %s", AN_GIT_DATE);
+    fits_write_history(ofptr, str, &status);
+    CFITS_CHECK("Failed to write GIT HISTORY headers");
+    free(str);
+    fits_write_history(ofptr, "Visit us on the web at http://astrometry.net/", &status);
+    CFITS_CHECK("Failed to write GIT HISTORY headers");
+
+    nimgs = 0;
+
+    for (kk=1; kk <= nhdus; kk++) {
+        long* fpixel;
+        int a;
+        int w, h;
+        int scale = downsample ? downsample : 1;
+        int ds_required = downsample_as_required;
+        anbool tryagain;
+
+        if (extension && kk != extension)
+            continue;
+
+        fits_movabs_hdu(fptr, kk, &hdutype, &status);
+        fits_get_hdu_type(fptr, &hdutype, &status);
+
+        if (hdutype != IMAGE_HDU) {
+            if (extension)
+                logerr("Requested extension %i in file %s is not an image.\n", extension, infn);
+            continue;
+        }
+
+        fits_get_img_dim(fptr, &naxis, &status);
+        CFITS_CHECK("Failed to find image dimensions for HDU %i", kk);
+
+        fits_get_img_size(fptr, 2, naxisn, &status);
+        CFITS_CHECK("Failed to find image dimensions for HDU %i", kk);
+
+        nimgs++;
+
+        logverb("Got naxis=%d, na1=%lu, na2=%lu\n", naxis, naxisn[0], naxisn[1]);
+
+        fpixel = malloc(naxis * sizeof(long));
+        if (!fpixel) {
+            SYSERROR("Failed to allocate FITS pixel coordinate array");
+            goto bailout;
+        }
+        for (a=0; a<naxis; a++)
+            fpixel[a] = 1;
+
+        if (plane && naxis == 3) {
+            if (plane <= naxisn[2]) {
+                logmsg("Grabbing image plane %i\n", plane);
+                fpixel[2] = plane;
+            } else
+                logerr("Requested plane %i but only %i are available.\n", plane, (int)naxisn[2]);
+        } else if (plane)
+            logmsg("Plane %i requested but this image has NAXIS = %i (not 3).\n", plane, naxis);
+        else if (naxis > 2)
+            logmsg("This looks like a multi-color image: processing the first image plane only.  (NAXIS=%i)\n", naxis);
+
+        simplexy_fill_in_defaults(params);
+
+        params->image = malloc(naxisn[0] * naxisn[1] * sizeof(float));
+        if (!params->image) {
+            SYSERROR("Failed to allocate image array");
+            free(fpixel);
+            goto bailout;
+        }
+        fits_read_pix(fptr, TFLOAT, fpixel, naxisn[0]*naxisn[1], NULL,
+                      params->image, NULL, &status);
+        free(fpixel);
+        CFITS_CHECK("Failed to read image pixels");
+
+        params->nx = naxisn[0];
+        params->ny = naxisn[1];
+
+        if (downsample && downsample > 1) {
+            logmsg("Downsampling by %i...\n", downsample);
+            if (sep_downsample_image(&params->image, &params->nx, &params->ny, downsample))
+                goto bailout;
+        }
+
+        do {
+            tryagain = FALSE;
+            if (sep_extract_image(params, scale))
+                goto bailout;
+            if (params->npeaks == 0 && ds_required) {
+                logmsg("Downsampling by 2...\n");
+                if (sep_downsample_image(&params->image, &params->nx, &params->ny, 2))
+                    goto bailout;
+                scale *= 2;
+                ds_required--;
+                tryagain = TRUE;
+            }
+        } while (tryagain);
+
+        w = naxisn[0];
+        h = naxisn[1];
+        if (write_source_table(ofptr, params, kk, w, h, "sep", &status))
+            goto bailout;
+
+        simplexy_free_contents(params);
+    }
+
+    fits_movabs_hdu(ofptr, 1, &hdutype, &status);
+    assert(hdutype == IMAGE_HDU);
+    fits_write_key(ofptr, TINT, "NEXTEND", &nimgs, "Number of extensions", &status);
+    if (status == END_OF_FILE)
+        status = 0;
+    CFITS_CHECK("Failed to write NEXTEND");
+
+    fits_close_file(fptr, &status);
+    CFITS_CHECK("Failed to close FITS input file");
+    fptr = NULL;
+
+    fits_close_file(ofptr, &status);
+    CFITS_CHECK("Failed to close FITS output file");
+
+    return 0;
+
+ bailout:
+    simplexy_free_contents(params);
+    if (fptr)
+        fits_close_file(fptr, &status);
+    if (ofptr)
+        fits_close_file(ofptr, &status);
+    return -1;
+}
+
+#else
+
+int image2xy_files_sep(const char* infn, const char* outfn,
+                       int downsample, int downsample_as_required,
+                       int extension, int plane,
+                       simplexy_t* params) {
+    (void)infn;
+    (void)outfn;
+    (void)downsample;
+    (void)downsample_as_required;
+    (void)extension;
+    (void)plane;
+    (void)params;
+    ERROR("SEP source extraction requested, but this binary was built without SEP support.  Rebuild with HAVE_SEP=yes SEP_INC=... SEP_LIB=...");
+    return -1;
+}
+
+#endif

--- a/solver/image2xy-main.c
+++ b/solver/image2xy-main.c
@@ -9,6 +9,7 @@
 #include <assert.h>
 #include <sys/types.h>
 #include <unistd.h>
+#include <getopt.h>
 
 #include "os-features.h"
 #include "image2xy-files.h"
@@ -17,6 +18,17 @@
 #include "ioutils.h"
 
 static const char* OPTIONS = "hi:Oo:8Hd:D:ve:B:S:M:s:p:P:bU:g:C:m:a:G:w:L:";
+
+enum {
+    OPT_SOURCE_BACKEND = 256,
+    OPT_USE_SEP
+};
+
+static struct option long_options[] = {
+    {"source-backend", required_argument, NULL, OPT_SOURCE_BACKEND},
+    {"use-sep", no_argument, NULL, OPT_USE_SEP},
+    {0, 0, 0, 0}
+};
 
 static void printHelp() {
     fprintf(stderr,
@@ -42,6 +54,8 @@ static void printHelp() {
             "   [-b]: don't do (median-based) background subtraction\n"
             "   [-G <background>]: subtract this 'global' background value; implies -b\n"
             "   [-m]: set maximum extended object size for deblending (default %i pixels)\n"
+            "   [--source-backend simplexy|sep]: source extraction backend (default: simplexy)\n"
+            "   [--use-sep]: shorthand for --source-backend sep\n"
             "\n"
             "   [-S <background-subtracted image>]: save background-subtracted image to this filename (FITS float image)\n"
             "   [-B <background image>]: save background image to filename\n"
@@ -74,14 +88,28 @@ int main(int argc, char *argv[]) {
     int downsample_as_reqd = 0;
     int extension = 0;
     int plane = 0;
+    int use_sep = 0;
 
     simplexy_t sparams;
     simplexy_t* params = &sparams;
 
     memset(params, 0, sizeof(simplexy_t));
 
-    while ((argchar = getopt (argc, argv, OPTIONS)) != -1) {
+    while ((argchar = getopt_long(argc, argv, OPTIONS, long_options, NULL)) != -1) {
         switch (argchar) {
+        case OPT_SOURCE_BACKEND:
+            if (streq(optarg, "simplexy")) {
+                use_sep = 0;
+            } else if (streq(optarg, "sep")) {
+                use_sep = 1;
+            } else {
+                ERROR("Unknown image2xy source backend \"%s\".  Choices are: simplexy, sep", optarg);
+                exit(-1);
+            }
+            break;
+        case OPT_USE_SEP:
+            use_sep = 1;
+            break;
         case 'L':
             params->Lorder = atoi(optarg);
             break;
@@ -186,8 +214,11 @@ int main(int argc, char *argv[]) {
     if (downsample)
         logverb("Downsampling by %i\n", downsample);
 
-    if (image2xy_files(infn, outfn, do_u8, downsample, downsample_as_reqd,
-                       extension, plane, params)) {
+    if ((use_sep ?
+         image2xy_files_sep(infn, outfn, downsample, downsample_as_reqd,
+                            extension, plane, params) :
+         image2xy_files(infn, outfn, do_u8, downsample, downsample_as_reqd,
+                        extension, plane, params))) {
         ERROR("image2xy failed.");
         exit(-1);
     }

--- a/util/blur_score.py
+++ b/util/blur_score.py
@@ -1,0 +1,257 @@
+"""Blur score for astronomical images via stellar PSF measurement.
+
+Runs source-extractor to detect stars, takes the median FWHM and
+ellipticity of the brightest detections, and maps to a [0, 1] score
+(1 = sharp pinpoint stars, 0 = severely blurred).
+
+The score is FWHM-driven (penalizing wide PSFs from defocus / poor
+seeing), down-weighted by ellipticity (penalizing tracking-error
+streaks), and down-weighted by source count (severely blurred frames
+lose faint stars below the detection threshold). Satellite trails do
+not affect the score: the metric is local to detected stars, so a
+single bright trail on an otherwise sharp frame still scores high.
+"""
+import os
+import shutil
+import subprocess
+import tempfile
+import warnings
+import numpy as np
+
+DEFAULT_TARGET_FWHM = 3.0
+DETECT_THRESH = 5.0
+DETECT_MINAREA = 5
+MIN_SOURCES = 10
+MIN_BRIGHT = 4
+BRIGHT_QUANTILE = 0.7
+COUNT_SATURATION = 10
+FWHM_RANGE = (1.0, 30.0)
+SOURCE_EXTRACTOR = "source-extractor"
+FILTER_NAME = "/usr/share/source-extractor/gauss_3.0_5x5.conv"
+FITS_EXTS = (".fits", ".fit", ".fts")
+BACKEND_SOURCE_EXTRACTOR = "source-extractor"
+BACKEND_SIMPLEXY = "simplexy"
+BACKEND_SEP = "sep"
+SOURCE_BACKENDS = (BACKEND_SOURCE_EXTRACTOR, BACKEND_SIMPLEXY, BACKEND_SEP)
+
+
+class InsufficientSources(RuntimeError):
+    pass
+
+
+def to_grayscale(image):
+    """Accept a path or ndarray. Return float32 2D array (no resampling)."""
+    if isinstance(image, str):
+        if os.path.splitext(image)[1].lower() in FITS_EXTS:
+            from astropy.io import fits
+            with fits.open(image) as hdul:
+                arr = hdul[0].data
+        else:
+            from PIL import Image
+            arr = np.asarray(Image.open(image).convert("F"))
+    else:
+        arr = np.asarray(image)
+    arr = arr.astype(np.float32, copy=False)
+    if arr.ndim == 3:
+        arr = (0.2989 * arr[..., 0] + 0.5870 * arr[..., 1]
+               + 0.1140 * arr[..., 2]) if arr.shape[2] >= 3 else arr[..., 0]
+    elif arr.ndim != 2:
+        raise ValueError(f"Unsupported image shape: {arr.shape}")
+    return arr.astype(np.float32, copy=False)
+
+
+def _ensure_fits(image, workdir):
+    if isinstance(image, str) and os.path.splitext(image)[1].lower() in FITS_EXTS:
+        return os.path.abspath(image)
+    from astropy.io import fits
+    out = os.path.join(workdir, "in.fits")
+    fits.PrimaryHDU(to_grayscale(image)).writeto(out, overwrite=True)
+    return out
+
+
+def _image2xy_executable(image2xy_path=None):
+    if image2xy_path:
+        if os.path.sep in image2xy_path or (os.path.altsep and os.path.altsep in image2xy_path):
+            return os.path.abspath(image2xy_path)
+        return shutil.which(image2xy_path) or image2xy_path
+    repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
+    candidate = os.path.join(repo_root, "solver", "image2xy")
+    if os.path.exists(candidate):
+        return candidate
+    found = shutil.which("image2xy")
+    if found:
+        return found
+    raise FileNotFoundError("image2xy executable not found; build solver/image2xy first")
+
+
+def _read_xyls_sources(cat_file):
+    from astropy.io import fits
+    fwhm_parts = []
+    ecc_parts = []
+    flux_parts = []
+
+    with fits.open(cat_file) as hdul:
+        for hdu in hdul[1:]:
+            data = hdu.data
+            if data is None or len(data) == 0:
+                continue
+            names = set(data.names or [])
+            if not {"FWHM_IMAGE", "ELLIPTICITY", "FLUX"}.issubset(names):
+                continue
+            fwhm_parts.append(np.asarray(data["FWHM_IMAGE"], dtype=np.float64))
+            ecc_parts.append(np.asarray(data["ELLIPTICITY"], dtype=np.float64))
+            flux_parts.append(np.asarray(data["FLUX"], dtype=np.float64))
+
+    if not fwhm_parts:
+        empty = np.empty(0, dtype=np.float64)
+        return empty, empty, empty
+    return np.concatenate(fwhm_parts), np.concatenate(ecc_parts), np.concatenate(flux_parts)
+
+
+def _detect_sources_image2xy(image, backend,
+                             detect_thresh=DETECT_THRESH,
+                             downsample=0,
+                             downsample_as_required=3,
+                             image2xy_path=None):
+    with tempfile.TemporaryDirectory() as td:
+        fits_path = _ensure_fits(image, td)
+        cat_file = os.path.join(td, "image2xy.xyls")
+        cmd = [
+            _image2xy_executable(image2xy_path),
+            "--source-backend", backend,
+            "-O",
+            "-o", cat_file,
+            "-p", str(detect_thresh),
+        ]
+        if downsample:
+            cmd.extend(["-d", str(downsample)])
+        if downsample_as_required:
+            cmd.extend(["-D", str(downsample_as_required)])
+        cmd.append(fits_path)
+        subprocess.run(cmd, check=True, capture_output=True, cwd=td)
+        fwhm, ecc, flux = _read_xyls_sources(cat_file)
+
+    keep = (
+        np.isfinite(fwhm) & np.isfinite(ecc) & np.isfinite(flux) &
+        (fwhm > FWHM_RANGE[0]) & (fwhm < FWHM_RANGE[1])
+    )
+    return fwhm[keep], ecc[keep], flux[keep]
+
+
+def detect_sources(image,
+                   detect_thresh=DETECT_THRESH,
+                   detect_minarea=DETECT_MINAREA,
+                   backend=BACKEND_SOURCE_EXTRACTOR,
+                   **kwargs):
+    """Return (fwhm, ellipticity, flux) arrays for FLAGS==0 sources whose
+    FWHM falls inside FWHM_RANGE."""
+    if backend not in SOURCE_BACKENDS:
+        raise ValueError(f"Unknown source extraction backend: {backend}")
+    if backend in (BACKEND_SIMPLEXY, BACKEND_SEP):
+        return _detect_sources_image2xy(
+            image,
+            backend,
+            detect_thresh=detect_thresh,
+            **kwargs
+        )
+
+    with tempfile.TemporaryDirectory() as td:
+        fits_path = _ensure_fits(image, td)
+        param_file = os.path.join(td, "sex.param")
+        with open(param_file, "w") as f:
+            f.write("FWHM_IMAGE\nELLIPTICITY\nFLAGS\nFLUX_AUTO\n")
+        cat_file = os.path.join(td, "sex.cat")
+        subprocess.run([
+            SOURCE_EXTRACTOR, fits_path,
+            "-CATALOG_NAME", cat_file,
+            "-CATALOG_TYPE", "ASCII_HEAD",
+            "-PARAMETERS_NAME", param_file,
+            "-DETECT_THRESH", str(detect_thresh),
+            "-ANALYSIS_THRESH", str(detect_thresh),
+            "-DETECT_MINAREA", str(detect_minarea),
+            "-FILTER", "Y",
+            "-FILTER_NAME", FILTER_NAME,
+            "-VERBOSE_TYPE", "QUIET",
+        ], check=True, capture_output=True, cwd=td)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            data = np.loadtxt(cat_file, ndmin=2)
+    if data.size == 0:
+        empty = np.empty(0, dtype=np.float64)
+        return empty, empty, empty
+    fwhm, ecc, flags, flux = data[:, 0], data[:, 1], data[:, 2], data[:, 3]
+    keep = (flags == 0) & (fwhm > FWHM_RANGE[0]) & (fwhm < FWHM_RANGE[1])
+    return fwhm[keep], ecc[keep], flux[keep]
+
+
+def measure_psf(image, bright_quantile=BRIGHT_QUANTILE, **kwargs):
+    """Return (median_fwhm, median_ellipticity, n_bright_sources).
+
+    Restricts the median to the brightest `bright_quantile` of detected
+    sources (top 30% by FLUX_AUTO by default), so faint detections and
+    leftover noise blobs don't wash out the PSF signal coming from real
+    reference stars. Raises InsufficientSources when fewer than
+    MIN_SOURCES total or MIN_BRIGHT bright sources are detected."""
+    fwhm, ecc, flux = detect_sources(image, **kwargs)
+    if len(fwhm) < MIN_SOURCES:
+        raise InsufficientSources(
+            f"only {len(fwhm)} clean sources detected (need >= {MIN_SOURCES})"
+        )
+    bright = flux >= np.quantile(flux, bright_quantile)
+    if bright.sum() < MIN_BRIGHT:
+        raise InsufficientSources(
+            f"only {int(bright.sum())} bright sources above quantile "
+            f"{bright_quantile} (need >= {MIN_BRIGHT})"
+        )
+    return float(np.median(fwhm[bright])), float(np.median(ecc[bright])), int(bright.sum())
+
+
+def compute_blur_score(image, target_fwhm=DEFAULT_TARGET_FWHM, **kwargs):
+    """Return blur score in [0, 1]. 1 = sharp, 0 = severely blurred.
+
+    score = fwhm_score * shape_weight * count_weight, where
+        fwhm_score   = clip(target_fwhm / median_bright_fwhm, 0, 1)
+        shape_weight = clip(1 - median_bright_ellipticity, 0, 1)
+        count_weight = clip(n_bright / COUNT_SATURATION, 0, 1)
+    """
+    return score_from_psf(*measure_psf(image, **kwargs), target_fwhm=target_fwhm)
+
+
+def score_from_psf(fwhm, ecc, n_bright, target_fwhm):
+    fwhm_score = min(1.0, target_fwhm / fwhm) if fwhm > 0 else 0.0
+    shape_weight = max(0.0, 1.0 - ecc)
+    count_weight = min(1.0, n_bright / COUNT_SATURATION)
+    return float(fwhm_score * shape_weight * count_weight)
+
+
+def _main(argv=None):
+    import argparse, sys
+    p = argparse.ArgumentParser(
+        prog="blur_score",
+        description="Astro blur score (1 = sharp, 0 = blurred) via stellar PSF.",
+    )
+    p.add_argument("image")
+    p.add_argument("--backend", choices=SOURCE_BACKENDS, default=BACKEND_SOURCE_EXTRACTOR)
+    p.add_argument("--image2xy-path",
+                   help="Path to image2xy for simplexy/sep backends.")
+    p.add_argument("--target-fwhm", type=float, default=DEFAULT_TARGET_FWHM)
+    p.add_argument("--detect-thresh", type=float, default=DETECT_THRESH)
+    p.add_argument("--raw", action="store_true",
+                   help="Print 'fwhm=... ellipticity=... n_sources=...' instead of the score.")
+    args = p.parse_args(argv)
+    try:
+        f, e, n = measure_psf(args.image, detect_thresh=args.detect_thresh,
+                              backend=args.backend,
+                              image2xy_path=args.image2xy_path)
+    except InsufficientSources as ex:
+        print(f"insufficient_sources: {ex}", file=sys.stderr)
+        return 2
+    if args.raw:
+        print(f"fwhm={f:.3f} ellipticity={e:.3f} n_sources={n}")
+    else:
+        print(score_from_psf(f, e, n, args.target_fwhm))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/util/blur_score_benchmark.py
+++ b/util/blur_score_benchmark.py
@@ -1,0 +1,204 @@
+"""Benchmark blur_score over a directory or list of astronomical images.
+
+Outputs CSV: backend,image,elapsed_s,status,fwhm,ellipticity,n_sources,score,error.
+
+Usage:
+    python -m astrometry.util.blur_score_benchmark \
+        --images-dir /src/Astrometry-testing-data/data
+    python -m astrometry.util.blur_score_benchmark \
+        --paths img1.png img2.fits ...
+    python -m astrometry.util.blur_score_benchmark \
+        --images-dir /src/Astrometry-testing-data/data --backend sep --jobs 4
+"""
+import argparse
+from concurrent.futures import ThreadPoolExecutor
+import csv
+import os
+import sys
+import time
+
+from .blur_score import (
+    DEFAULT_TARGET_FWHM,
+    InsufficientSources,
+    SOURCE_BACKENDS,
+    measure_psf,
+    score_from_psf,
+)
+
+DEFAULT_IMAGES_DIR = "/src/Astrometry-testing-data/data"
+IMG_EXTS = (".fits", ".fit", ".fts", ".png", ".jpg", ".jpeg", ".tif", ".tiff")
+
+
+def _walk_images(root):
+    out = []
+    for dirpath, _, files in os.walk(root):
+        for fn in files:
+            if fn.lower().endswith(IMG_EXTS):
+                out.append(os.path.join(dirpath, fn))
+    out.sort()
+    return out
+
+
+def _measure_one(task):
+    backend, path, opts = task
+    start = time.perf_counter()
+    try:
+        f, e, n = measure_psf(
+            path,
+            backend=backend,
+            detect_thresh=opts["detect_thresh"],
+            downsample=opts["downsample"],
+            downsample_as_required=opts["downsample_as_required"],
+            image2xy_path=opts["image2xy_path"],
+        )
+    except InsufficientSources as ex:
+        elapsed = time.perf_counter() - start
+        return {
+            "backend": backend,
+            "path": path,
+            "elapsed": elapsed,
+            "status": "insufficient_sources",
+            "fwhm": "nan",
+            "ellipticity": "nan",
+            "n_sources": 0,
+            "score": "nan",
+            "error": str(ex),
+        }
+    except Exception as ex:
+        elapsed = time.perf_counter() - start
+        return {
+            "backend": backend,
+            "path": path,
+            "elapsed": elapsed,
+            "status": "error",
+            "fwhm": "nan",
+            "ellipticity": "nan",
+            "n_sources": 0,
+            "score": "nan",
+            "error": str(ex),
+        }
+
+    elapsed = time.perf_counter() - start
+    return {
+        "backend": backend,
+        "path": path,
+        "elapsed": elapsed,
+        "status": "ok",
+        "fwhm": f"{f:.4f}",
+        "ellipticity": f"{e:.4f}",
+        "n_sources": n,
+        "score": f"{score_from_psf(f, e, n, opts['target_fwhm']):.4f}",
+        "error": "",
+    }
+
+
+def _write_result(writer, result):
+    writer.writerow([
+        result["backend"],
+        result["path"],
+        f"{result['elapsed']:.6f}",
+        result["status"],
+        result["fwhm"],
+        result["ellipticity"],
+        result["n_sources"],
+        result["score"],
+        result["error"],
+    ])
+
+
+def _run_backend(backend, files, opts, jobs, writer):
+    summary = {"ok": 0, "insufficient": 0, "error": 0, "elapsed": 0.0}
+    tasks = [(backend, path, opts) for path in files]
+    start = time.perf_counter()
+
+    if jobs == 1:
+        results = map(_measure_one, tasks)
+    else:
+        pool = ThreadPoolExecutor(max_workers=jobs)
+        results = pool.map(_measure_one, tasks)
+
+    try:
+        for result in results:
+            if result["status"] == "ok":
+                summary["ok"] += 1
+            elif result["status"] == "insufficient_sources":
+                summary["insufficient"] += 1
+            else:
+                summary["error"] += 1
+            summary["elapsed"] += result["elapsed"]
+            _write_result(writer, result)
+    finally:
+        if jobs != 1:
+            pool.shutdown()
+
+    summary["wall"] = time.perf_counter() - start
+    return summary
+
+
+def main(argv=None):
+    p = argparse.ArgumentParser(prog="blur_score_benchmark")
+    p.add_argument("--images-dir", default=DEFAULT_IMAGES_DIR)
+    p.add_argument("--paths", nargs="*",
+                   help="Specific image paths (overrides --images-dir walk)")
+    p.add_argument("--backend", action="append",
+                   choices=SOURCE_BACKENDS + ("all",),
+                   help="Source extraction backend. Repeat to compare backends, or use 'all'.")
+    p.add_argument("--detect-thresh", type=float, default=5.0)
+    p.add_argument("--downsample", type=int, default=0)
+    p.add_argument("--downsample-as-required", type=int, default=3)
+    p.add_argument("--image2xy-path",
+                   help="Path to image2xy for simplexy/sep backends.")
+    p.add_argument("--max-images", type=int,
+                   help="Limit the number of images for quick benchmark runs.")
+    p.add_argument("--jobs", type=int, default=4,
+                   help="Number of images to process in parallel per backend.")
+    p.add_argument("--target-fwhm", type=float, default=DEFAULT_TARGET_FWHM)
+    args = p.parse_args(argv)
+    if args.jobs < 1:
+        p.error("--jobs must be >= 1")
+
+    backends = args.backend or ["source-extractor"]
+    if "all" in backends:
+        backends = list(SOURCE_BACKENDS)
+
+    if args.paths:
+        files = args.paths
+    elif os.path.isdir(args.images_dir):
+        files = _walk_images(args.images_dir)
+    else:
+        print(f"images-dir not found: {args.images_dir}", file=sys.stderr)
+        return 2
+    if args.max_images:
+        files = files[:args.max_images]
+
+    writer = csv.writer(sys.stdout)
+    writer.writerow([
+        "backend", "image", "elapsed_s", "status",
+        "fwhm", "ellipticity", "n_sources", "score", "error"
+    ])
+
+    opts = {
+        "detect_thresh": args.detect_thresh,
+        "downsample": args.downsample,
+        "downsample_as_required": args.downsample_as_required,
+        "image2xy_path": args.image2xy_path,
+        "target_fwhm": args.target_fwhm,
+    }
+    summary = {}
+    for backend in backends:
+        summary[backend] = _run_backend(backend, files, opts, args.jobs, writer)
+        item = summary[backend]
+        total = item["ok"] + item["insufficient"] + item["error"]
+        print(
+            "# summary "
+            f"backend={backend} total={total} ok={item['ok']} "
+            f"insufficient={item['insufficient']} error={item['error']} "
+            f"elapsed_s={item['elapsed']:.3f} wall_s={item['wall']:.3f} "
+            f"jobs={args.jobs}",
+            file=sys.stderr
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/util/image2xy.c
+++ b/util/image2xy.c
@@ -103,6 +103,8 @@ int image2xy_run(simplexy_t* s,
         // center of the lower-left pixel is (1,1).
         (s->x)[jj] = ((s->x)[jj] + 0.5) * (double)S + 0.5;
         (s->y)[jj] = ((s->y)[jj] + 0.5) * (double)S + 0.5;
+        if (s->fwhm)
+            (s->fwhm)[jj] *= (float)S;
     }
 
     dselip_cleanup();
@@ -114,4 +116,3 @@ int image2xy_run(simplexy_t* s,
     }
     return rtn;
 }
-

--- a/util/makefile.sep
+++ b/util/makefile.sep
@@ -1,0 +1,16 @@
+# Optional SEP (Source Extraction and Photometry) support.
+#
+# Autodetect when a pkg-config file exists, or force it with:
+#   make HAVE_SEP=yes SEP_INC="-I/path/include" SEP_LIB="-L/path/lib -lsep"
+
+HAVE_SEP ?= $(shell pkg-config --exists sep 2>/dev/null && echo yes || echo no)
+
+ifeq ($(HAVE_SEP),yes)
+SEP_INC ?= $(shell pkg-config --cflags sep 2>/dev/null)
+SEP_LIB ?= $(shell pkg-config --libs sep 2>/dev/null || echo -lsep)
+SEP_CFLAGS := -DHAVE_SEP
+else
+SEP_INC :=
+SEP_LIB :=
+SEP_CFLAGS :=
+endif

--- a/util/missing_objects_eval.py
+++ b/util/missing_objects_eval.py
@@ -1,0 +1,493 @@
+"""Evaluate solver tolerance to missing detected objects.
+
+This utility has three subcommands:
+
+  score   - compute blur scores for an image folder
+  select  - choose a stratified sample by blur-score band
+  run     - solve selected images and rerun with rows removed from .axy files
+
+It injects the missing-object fault after source extraction by deleting rows
+from the generated .axy source table. Original images are never modified.
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import math
+import os
+import random
+import re
+import signal
+import subprocess
+import sys
+import time
+from concurrent.futures import ProcessPoolExecutor
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+from astropy.io import fits
+
+try:
+    from .blur_score import (
+        DEFAULT_TARGET_FWHM,
+        InsufficientSources,
+        measure_psf,
+        score_from_psf,
+    )
+except ImportError:
+    from astrometry.util.blur_score import (
+        DEFAULT_TARGET_FWHM,
+        InsufficientSources,
+        measure_psf,
+        score_from_psf,
+    )
+
+
+IMG_EXTS = (".fits", ".fit", ".fts", ".png", ".jpg", ".jpeg", ".tif", ".tiff")
+DEFAULT_BANDS = (
+    ("0.50-0.70", 0.50, 0.70, 10),
+    ("0.70-0.85", 0.70, 0.85, 10),
+    ("0.85-1.00", 0.85, 1.000000001, 10),
+)
+SCORE_FIELDS = ("image", "status", "fwhm", "ellipticity", "n_sources", "score", "error")
+SELECTION_FIELDS = ("image", "band", "score", "fwhm", "ellipticity", "n_sources")
+RESULT_FIELDS = (
+    "image",
+    "band",
+    "score",
+    "baseline_solved",
+    "baseline_time_sec",
+    "baseline_ra",
+    "baseline_dec",
+    "baseline_n_sources",
+    "missing_fraction",
+    "seed",
+    "missing_count",
+    "kept_count",
+    "solved",
+    "correct",
+    "solve_time_sec",
+    "center_ra",
+    "center_dec",
+    "center_sep_deg",
+    "returncode",
+    "output_dir",
+    "error",
+)
+
+
+@dataclass(frozen=True)
+class SolveResult:
+    solved: bool
+    elapsed_sec: float
+    returncode: int
+    ra: float
+    dec: float
+    output: str
+    error: str
+
+
+def iter_images(root: Path) -> list[Path]:
+    paths: list[Path] = []
+    for dirpath, _, filenames in os.walk(root):
+        for filename in filenames:
+            if filename.lower().endswith(IMG_EXTS):
+                paths.append(Path(dirpath) / filename)
+    return sorted(paths)
+
+
+def safe_float(value: str) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return math.nan
+
+
+def _score_one(payload: tuple[str, float]) -> dict[str, str]:
+    image, target_fwhm = payload
+    try:
+        fwhm, ecc, n_sources = measure_psf(image)
+        score = score_from_psf(fwhm, ecc, n_sources, target_fwhm)
+        return {
+            "image": image,
+            "status": "ok",
+            "fwhm": f"{fwhm:.6f}",
+            "ellipticity": f"{ecc:.6f}",
+            "n_sources": str(n_sources),
+            "score": f"{score:.6f}",
+            "error": "",
+        }
+    except InsufficientSources as exc:
+        return {
+            "image": image,
+            "status": "insufficient_sources",
+            "fwhm": "nan",
+            "ellipticity": "nan",
+            "n_sources": "0",
+            "score": "nan",
+            "error": str(exc),
+        }
+    except Exception as exc:
+        return {
+            "image": image,
+            "status": "error",
+            "fwhm": "nan",
+            "ellipticity": "nan",
+            "n_sources": "0",
+            "score": "nan",
+            "error": str(exc),
+        }
+
+
+def command_score(args: argparse.Namespace) -> int:
+    images = iter_images(Path(args.images_dir))
+    if args.limit:
+        images = images[: args.limit]
+    if not images:
+        print(f"No images found under {args.images_dir}", file=sys.stderr)
+        return 2
+
+    Path(args.output).parent.mkdir(parents=True, exist_ok=True)
+    payloads = [(str(path), args.target_fwhm) for path in images]
+    with open(args.output, "w", newline="") as out:
+        writer = csv.DictWriter(out, fieldnames=SCORE_FIELDS)
+        writer.writeheader()
+        if args.workers == 1:
+            iterator = map(_score_one, payloads)
+        else:
+            pool = ProcessPoolExecutor(max_workers=args.workers)
+            iterator = pool.map(_score_one, payloads)
+        try:
+            for i, row in enumerate(iterator, 1):
+                writer.writerow(row)
+                if i % args.progress_every == 0:
+                    print(f"scored {i}/{len(images)} images", file=sys.stderr, flush=True)
+        finally:
+            if args.workers != 1:
+                pool.shutdown(wait=True)
+    print(f"Wrote blur scores: {args.output}")
+    return 0
+
+
+def in_band(score: float, low: float, high: float) -> bool:
+    return low <= score < high
+
+
+def command_select(args: argparse.Namespace) -> int:
+    rng = random.Random(args.seed)
+    rows_by_band: dict[str, list[dict[str, str]]] = {name: [] for name, _, _, _ in DEFAULT_BANDS}
+    with open(args.scores, newline="") as f:
+        for row in csv.DictReader(f):
+            if row.get("status") != "ok":
+                continue
+            score = safe_float(row.get("score", "nan"))
+            if not math.isfinite(score):
+                continue
+            for name, low, high, _ in DEFAULT_BANDS:
+                if in_band(score, low, high):
+                    rows_by_band[name].append(row)
+                    break
+
+    selected: list[dict[str, str]] = []
+    for name, _, _, count in DEFAULT_BANDS:
+        rows = rows_by_band[name]
+        rng.shuffle(rows)
+        chosen = rows[:count]
+        print(f"{name}: selected {len(chosen)} of {len(rows)} candidates")
+        for row in chosen:
+            selected.append({
+                "image": row["image"],
+                "band": name,
+                "score": row["score"],
+                "fwhm": row["fwhm"],
+                "ellipticity": row["ellipticity"],
+                "n_sources": row["n_sources"],
+            })
+
+    Path(args.output).parent.mkdir(parents=True, exist_ok=True)
+    with open(args.output, "w", newline="") as out:
+        writer = csv.DictWriter(out, fieldnames=SELECTION_FIELDS)
+        writer.writeheader()
+        writer.writerows(selected)
+    print(f"Wrote selected sample: {args.output}")
+    return 0
+
+
+def slugify_image(path: str, index: int) -> str:
+    stem = Path(path).stem
+    slug = re.sub(r"[^A-Za-z0-9._-]+", "-", stem).strip("-")
+    if not slug:
+        slug = "image"
+    return f"{index:03d}-{slug}"
+
+
+def parse_center(output: str) -> tuple[float, float]:
+    match = re.search(r"Field center:\s+\(RA,Dec\)\s+=\s+\(([-+0-9.eE]+),\s*([-+0-9.eE]+)\)", output)
+    if not match:
+        return math.nan, math.nan
+    return float(match.group(1)), float(match.group(2))
+
+
+def angular_sep_deg(ra1: float, dec1: float, ra2: float, dec2: float) -> float:
+    if not all(math.isfinite(v) for v in (ra1, dec1, ra2, dec2)):
+        return math.nan
+    r1 = math.radians(ra1)
+    d1 = math.radians(dec1)
+    r2 = math.radians(ra2)
+    d2 = math.radians(dec2)
+    cos_sep = math.sin(d1) * math.sin(d2) + math.cos(d1) * math.cos(d2) * math.cos(r1 - r2)
+    cos_sep = max(-1.0, min(1.0, cos_sep))
+    return math.degrees(math.acos(cos_sep))
+
+
+def run_solve(
+    solve_field: str,
+    config: str,
+    input_path: Path,
+    outdir: Path,
+    cpulimit: int,
+    wall_timeout: float,
+    outbase: str = "solution",
+) -> SolveResult:
+    outdir.mkdir(parents=True, exist_ok=True)
+    cmd = [
+        solve_field,
+        "--config",
+        config,
+        "--dir",
+        str(outdir),
+        "--out",
+        outbase,
+        "--overwrite",
+        "--no-plots",
+        "--new-fits",
+        "none",
+        "--corr",
+        "none",
+        "--rdls",
+        "none",
+        "--match",
+        "none",
+        "--index-xyls",
+        "none",
+        "--cpulimit",
+        str(cpulimit),
+        str(input_path),
+    ]
+    start = time.perf_counter()
+    proc = subprocess.Popen(
+        cmd,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        preexec_fn=os.setsid,
+    )
+    timed_out = False
+    try:
+        stdout, stderr = proc.communicate(timeout=wall_timeout if wall_timeout > 0 else None)
+    except subprocess.TimeoutExpired:
+        timed_out = True
+        os.killpg(proc.pid, signal.SIGTERM)
+        try:
+            stdout, stderr = proc.communicate(timeout=5)
+        except subprocess.TimeoutExpired:
+            os.killpg(proc.pid, signal.SIGKILL)
+            stdout, stderr = proc.communicate()
+    elapsed = time.perf_counter() - start
+    combined = (stdout or "") + (stderr or "")
+    solved = (outdir / f"{outbase}.solved").exists() and (outdir / f"{outbase}.wcs").exists()
+    ra, dec = parse_center(combined)
+    err = ""
+    if timed_out:
+        err = f"wall timeout after {wall_timeout:.1f}s"
+    elif proc.returncode != 0:
+        err = combined.strip().splitlines()[-1] if combined.strip() else f"returncode={proc.returncode}"
+    elif not solved:
+        err = "not solved"
+    return SolveResult(solved, elapsed, proc.returncode, ra, dec, combined, err)
+
+
+def write_reduced_axy(source_axy: Path, dest_axy: Path, missing_fraction: float, seed: int) -> tuple[int, int, int]:
+    with fits.open(source_axy) as hdul:
+        table = hdul[1].data
+        n_rows = len(table)
+        missing_count = int(round(n_rows * missing_fraction))
+        missing_count = max(0, min(missing_count, n_rows))
+        if missing_count:
+            rng = np.random.default_rng(seed)
+            remove = set(int(i) for i in rng.choice(n_rows, size=missing_count, replace=False))
+            keep = np.array([i not in remove for i in range(n_rows)], dtype=bool)
+            reduced = table[keep]
+        else:
+            reduced = table
+
+        new_hdus = fits.HDUList([hdul[0].copy()])
+        new_hdus.append(fits.BinTableHDU(data=reduced, header=hdul[1].header.copy(), name=hdul[1].name))
+        dest_axy.parent.mkdir(parents=True, exist_ok=True)
+        new_hdus.writeto(dest_axy, overwrite=True)
+    return n_rows, missing_count, n_rows - missing_count
+
+
+def command_run(args: argparse.Namespace) -> int:
+    fractions = [float(x) for x in args.fractions.split(",") if x.strip()]
+    root = Path(args.output_dir)
+    root.mkdir(parents=True, exist_ok=True)
+
+    with open(args.selection, newline="") as f:
+        selected = list(csv.DictReader(f))
+    if args.limit:
+        selected = selected[: args.limit]
+
+    results_path = root / "missing_objects_results.csv"
+    with open(results_path, "w", newline="") as out:
+        writer = csv.DictWriter(out, fieldnames=RESULT_FIELDS)
+        writer.writeheader()
+        for image_index, row in enumerate(selected, 1):
+            image = row["image"]
+            slug = slugify_image(image, image_index)
+            image_root = root / slug
+
+            baseline = run_solve(
+                args.solve_field,
+                args.config,
+                Path(image),
+                image_root / "baseline",
+                args.cpulimit,
+                args.wall_timeout,
+            )
+            baseline_axy = image_root / "baseline" / "solution.axy"
+            baseline_n_sources = 0
+            if baseline_axy.exists():
+                with fits.open(baseline_axy) as hdul:
+                    baseline_n_sources = len(hdul[1].data)
+
+            if not baseline.solved or not baseline_axy.exists():
+                writer.writerow({
+                    "image": image,
+                    "band": row["band"],
+                    "score": row["score"],
+                    "baseline_solved": str(baseline.solved),
+                    "baseline_time_sec": f"{baseline.elapsed_sec:.3f}",
+                    "baseline_ra": f"{baseline.ra:.8f}" if math.isfinite(baseline.ra) else "nan",
+                    "baseline_dec": f"{baseline.dec:.8f}" if math.isfinite(baseline.dec) else "nan",
+                    "baseline_n_sources": str(baseline_n_sources),
+                    "missing_fraction": "",
+                    "seed": "",
+                    "missing_count": "",
+                    "kept_count": "",
+                    "solved": "False",
+                    "correct": "False",
+                    "solve_time_sec": "",
+                    "center_ra": "nan",
+                    "center_dec": "nan",
+                    "center_sep_deg": "nan",
+                    "returncode": str(baseline.returncode),
+                    "output_dir": str(image_root / "baseline"),
+                    "error": baseline.error,
+                })
+                out.flush()
+                print(f"[{image_index}/{len(selected)}] baseline failed: {image}")
+                continue
+
+            trial_specs: list[tuple[float, int]] = []
+            for fraction in fractions:
+                if fraction == 0:
+                    trial_specs.append((fraction, 0))
+                else:
+                    for seed_offset in range(args.seeds):
+                        trial_specs.append((fraction, args.seed + seed_offset))
+
+            for missing_fraction, seed in trial_specs:
+                trial_name = f"missing-{int(round(missing_fraction * 100)):03d}-seed-{seed:04d}"
+                trial_dir = image_root / trial_name
+                trial_axy = trial_dir / "input.axy"
+                n_rows, missing_count, kept_count = write_reduced_axy(
+                    baseline_axy,
+                    trial_axy,
+                    missing_fraction,
+                    seed,
+                )
+                result = run_solve(
+                    args.solve_field,
+                    args.config,
+                    trial_axy,
+                    trial_dir,
+                    args.cpulimit,
+                    args.wall_timeout,
+                )
+                sep = angular_sep_deg(baseline.ra, baseline.dec, result.ra, result.dec)
+                correct = result.solved and math.isfinite(sep) and sep <= args.max_center_sep_deg
+                writer.writerow({
+                    "image": image,
+                    "band": row["band"],
+                    "score": row["score"],
+                    "baseline_solved": "True",
+                    "baseline_time_sec": f"{baseline.elapsed_sec:.3f}",
+                    "baseline_ra": f"{baseline.ra:.8f}",
+                    "baseline_dec": f"{baseline.dec:.8f}",
+                    "baseline_n_sources": str(n_rows),
+                    "missing_fraction": f"{missing_fraction:.3f}",
+                    "seed": str(seed),
+                    "missing_count": str(missing_count),
+                    "kept_count": str(kept_count),
+                    "solved": str(result.solved),
+                    "correct": str(correct),
+                    "solve_time_sec": f"{result.elapsed_sec:.3f}",
+                    "center_ra": f"{result.ra:.8f}" if math.isfinite(result.ra) else "nan",
+                    "center_dec": f"{result.dec:.8f}" if math.isfinite(result.dec) else "nan",
+                    "center_sep_deg": f"{sep:.8f}" if math.isfinite(sep) else "nan",
+                    "returncode": str(result.returncode),
+                    "output_dir": str(trial_dir),
+                    "error": result.error,
+                })
+                out.flush()
+            print(f"[{image_index}/{len(selected)}] completed: {image}")
+    print(f"Wrote missing-object results: {results_path}")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="missing_objects_eval")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    score = subparsers.add_parser("score", help="compute blur scores for an image folder")
+    score.add_argument("--images-dir", required=True)
+    score.add_argument("--output", required=True)
+    score.add_argument("--target-fwhm", type=float, default=DEFAULT_TARGET_FWHM)
+    score.add_argument("--workers", type=int, default=max(1, min(4, os.cpu_count() or 1)))
+    score.add_argument("--limit", type=int, default=0)
+    score.add_argument("--progress-every", type=int, default=100)
+    score.set_defaults(func=command_score)
+
+    select = subparsers.add_parser("select", help="choose 10 images from each blur-score band")
+    select.add_argument("--scores", required=True)
+    select.add_argument("--output", required=True)
+    select.add_argument("--seed", type=int, default=42)
+    select.set_defaults(func=command_select)
+
+    run = subparsers.add_parser("run", help="run baseline and missing-object solve trials")
+    run.add_argument("--selection", required=True)
+    run.add_argument("--output-dir", required=True)
+    run.add_argument("--solve-field", default="/usr/local/astrometry/bin/solve-field")
+    run.add_argument("--config", default="/usr/local/astrometry/etc/astrometry.cfg")
+    run.add_argument("--cpulimit", type=int, default=60)
+    run.add_argument("--wall-timeout", type=float, default=0.0)
+    run.add_argument("--fractions", default="0,0.1,0.2,0.3,0.4,0.5,0.6,0.7,0.8")
+    run.add_argument("--seeds", type=int, default=5)
+    run.add_argument("--seed", type=int, default=42)
+    run.add_argument("--max-center-sep-deg", type=float, default=0.1)
+    run.add_argument("--limit", type=int, default=0)
+    run.set_defaults(func=command_run)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/util/simplexy.c
+++ b/util/simplexy.c
@@ -115,6 +115,87 @@ static void write_fits_i16_image(const int16_t* img, int nx, int ny, const char*
     if (fits_write_i16_image(img, nx, ny, fn)) exit(-1);
 }
 
+static float bgsub_value(const float* bgsub, const int16_t* bgsub_i16, int ind) {
+    if (bgsub)
+        return bgsub[ind];
+    return bgsub_i16[ind];
+}
+
+static void measure_source_shape(const float* bgsub, const int16_t* bgsub_i16,
+                                 int nx, int ny, float x, float y,
+                                 float dpsf, float* fwhm, float* ellipticity) {
+    const double fwhm_factor = 2.3548200450309493;
+    int radius = (int)ceil(MAX(4.0, 6.0 * (double)dpsf));
+    int ix = (int)(x + 0.5);
+    int iy = (int)(y + 0.5);
+    int xlo, xhi, ylo, yhi;
+    int i, j;
+    double sum = 0.0;
+    double sumx = 0.0;
+    double sumy = 0.0;
+    double xbar, ybar;
+    double mxx = 0.0;
+    double myy = 0.0;
+    double mxy = 0.0;
+    double trace, det, disc, lambda1, lambda2;
+
+    *fwhm = 0.0;
+    *ellipticity = 1.0;
+
+    radius = MIN(radius, 20);
+    xlo = MAX(0, ix - radius);
+    xhi = MIN(nx - 1, ix + radius);
+    ylo = MAX(0, iy - radius);
+    yhi = MIN(ny - 1, iy + radius);
+
+    for (j = ylo; j <= yhi; j++) {
+        for (i = xlo; i <= xhi; i++) {
+            double w = bgsub_value(bgsub, bgsub_i16, i + j * nx);
+            if (w <= 0.0)
+                continue;
+            sum += w;
+            sumx += w * i;
+            sumy += w * j;
+        }
+    }
+    if (sum <= 0.0)
+        return;
+
+    xbar = sumx / sum;
+    ybar = sumy / sum;
+
+    for (j = ylo; j <= yhi; j++) {
+        for (i = xlo; i <= xhi; i++) {
+            double dx, dy;
+            double w = bgsub_value(bgsub, bgsub_i16, i + j * nx);
+            if (w <= 0.0)
+                continue;
+            dx = i - xbar;
+            dy = j - ybar;
+            mxx += w * dx * dx;
+            myy += w * dy * dy;
+            mxy += w * dx * dy;
+        }
+    }
+
+    mxx /= sum;
+    myy /= sum;
+    mxy /= sum;
+
+    trace = mxx + myy;
+    det = mxx * myy - mxy * mxy;
+    disc = trace * trace - 4.0 * det;
+    if (disc < 0.0)
+        disc = 0.0;
+    lambda1 = 0.5 * (trace + sqrt(disc));
+    lambda2 = 0.5 * (trace - sqrt(disc));
+    if (lambda1 <= 0.0 || lambda2 < 0.0)
+        return;
+
+    *fwhm = (float)(fwhm_factor * sqrt((lambda1 + lambda2) / 2.0));
+    *ellipticity = (float)(1.0 - sqrt(lambda2 / lambda1));
+}
+
 
 void simplexy_fill_in_defaults(simplexy_t* s) {
     if (s->dpsf == 0)
@@ -166,6 +247,10 @@ void simplexy_free_contents(simplexy_t* s) {
     s->flux = NULL;
     free(s->background);
     s->background = NULL;
+    free(s->fwhm);
+    s->fwhm = NULL;
+    free(s->ellipticity);
+    s->ellipticity = NULL;
     free(s->fluxL);
     free(s->backgroundL);
     s->fluxL = s->backgroundL = NULL;
@@ -404,6 +489,8 @@ int simplexy_run(simplexy_t* s) {
     s->y   = realloc(s->y, s->npeaks * sizeof(float));
     s->flux       = malloc(s->npeaks * sizeof(float));
     s->background = malloc(s->npeaks * sizeof(float));
+    s->fwhm        = malloc(s->npeaks * sizeof(float));
+    s->ellipticity = malloc(s->npeaks * sizeof(float));
 
     if (s->Lorder) {
         s->fluxL       = malloc(s->npeaks * sizeof(float));
@@ -434,6 +521,8 @@ int simplexy_run(simplexy_t* s) {
 
         s->flux[i] -= s->globalbg;
         s->background[i] += s->globalbg;
+        measure_source_shape(bgsub, bgsub_i16, nx, ny, s->x[i], s->y[i],
+                             s->dpsf, s->fwhm + i, s->ellipticity + i);
 
         if (s->Lorder) {
             lanczos_args_t L;
@@ -494,4 +583,3 @@ int simplexy_run(simplexy_t* s) {
 void simplexy_clean_cache() {
     dselip_cleanup();
 }
-


### PR DESCRIPTION
es gibt 2 Optionen um dies zu testen einmal über der Source_extractor selbst und das einmal über SEP c-library lokal installiert.
macht das selbe was source_extractor da macht aber schneller ist aber weniger zu verlässig als source_extractor

Source_extractor ist 100ms teuerer

# ACHTUNG !!!! 

> Parallelisierung ist da zum teil implemntiert Anzahl der Kerne ist Konfigurierbar 
### JOBS Anzahl ändern

## Source_extractor Testen:
```bash
/usr/bin/time -v python3 -m astrometry.util.blur_score_benchmark \
    --images-dir /home/mohammadibrahim/Astrometry-testing-data/data \
    --backend sep \
    --jobs 4 \
    > eval/blur_sep_parallel_jobs8.csv \
    2> eval/blur_sep_parallel_jobs8.log
```

## SEP Testen:


```bash
/usr/bin/time -v python3 -m astrometry.util.blur_score_benchmark \
    --images-dir /home/mohammadibrahim/Astrometry-testing-data/data \
    --backend sep \
    --jobs 4 \
    > eval/blur_sep_parallel.csv \
    2> eval/blur_sep_parallel.log
```